### PR TITLE
detect // as a comment too

### DIFF
--- a/syntax/pgspec.vim
+++ b/syntax/pgspec.vim
@@ -2,6 +2,7 @@ syntax include @sql syntax/sql.vim
 
 syntax keyword specKeyword setup teardown session step permutation
 syntax match specComment /^\#.*/
+syntax match specComment /\/\/.*/
 syntax region specString start=/"/  skip=/\\./  end=/"/
 syntax region specSQL start=/{/ end=/}/ contains=@sql
 


### PR DESCRIPTION
In Citus we run the spec files through the C preprocesser, 
so we use // as comments instead of # now.